### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]


### PR DESCRIPTION
Potential fix for [https://github.com/kenzings/crm-client/security/code-scanning/1](https://github.com/kenzings/crm-client/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job so that the `GITHUB_TOKEN` has only the minimal privileges required. For this simple Node.js CI build, all steps only need to read the repository contents; they do not push commits, create releases, or modify issues/PRs. Therefore, setting `contents: read` at the job level is sufficient and preserves existing behavior.

Concretely, in `.github/workflows/node.js.yml`, under the `build` job (right below `runs-on: ubuntu-latest` is a clear and common place), add:

```yaml
    permissions:
      contents: read
```

This limits the `GITHUB_TOKEN` for the `build` job to read-only access to repository contents, satisfying the CodeQL warning and following the principle of least privilege. No other lines or behavior in the workflow need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
